### PR TITLE
Update for Middleman 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,15 @@
 # the following line to use "http://" instead
 source 'https://rubygems.org'
 
-gem "middleman", "~>3.4.0"
+gem "middleman", "~>4.1.2"
+gem "middleman-sprockets", "~> 4.0.0.rc"
+gem "middleman-compass"
 
 # Vendor prefixes for sass
 gem 'middleman-autoprefixer'
 
 # Live-reloading plugin
-gem "middleman-livereload", "~> 3.1.0"
+gem "middleman-livereload", "~> 3.4"
 
 # For faster file watcher updates on Windows:
 gem "wdm", "~> 0.1.0", :platforms => [:mswin, :mingw]

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "foundation-sites": "~6.0.5",
+    "foundation-sites": "~6.2",
     "modernizr": "~2.8.3"
   }
 }

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -5,7 +5,7 @@
     %meta{:charset => "utf-8"}
     %meta{:content => "ie=edge", "http-equiv" => "x-ua-compatible"}
     %meta{:content => "width=device-width, initial-scale=1.0", :name => "viewport"}
-    %title= data.page.title
+    %title= current_resource.data.title
     = stylesheet_link_tag "style"
     = javascript_include_tag "modernizr"
   %body{:class => page_classes}


### PR DESCRIPTION
Update for Middleman 4.1.2
- Added gems to Gemfile which were extracted
- updated layout template to use `current_resource` instead of the removed `page` template local
- updated foundation-sites dependency to 6.2, as 6.0.5 displays deprecation errors.
