### PR TITLE
Updated MM4 Readme to better reflect changes in MM Project Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Lots of this is based on [middleman-zurb-foundation](https://github.com/axyz/mid
 
 ## Installing middleman-foundadtion-6 as a Middleman Template
 
-1. $ `git clone git://github.com/paperdigits/middleman-foundation-6.git ~/.middleman/middleman-foundation-6`
-1. $ `middleman init my_new_project --template=middleman-foundation-6`
+1. $ `middleman init my_new_project --template=paperdigits/middleman-foundation-6`
 1. $ `cd my_new_project`
 1. $ `bower install`
-1. $ `bundle install`
 1. $ `bundle exec middleman`
 
 Now you can start hacking on `source` directory and watch live changes on [localhost:4567](http://localhost:4567).

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Lots of this is based on [middleman-zurb-foundation](https://github.com/axyz/mid
 
 Now you can start hacking on `source` directory and watch live changes on [localhost:4567](http://localhost:4567).
 
-For more help follow [Middleman's project template instructions](http://middlemanapp.com/getting-started/welcome/).
+For more help follow [Middleman's project template instructions](https://middlemanapp.com/advanced/project_templates/).


### PR DESCRIPTION
I'm submitting some small changes to reflect the way MM4 now does project templates. You no longer clone the repository yourself, as you just provide the Github username/repo combination and it does the rest.

It also runs bundle install for you, so I have removed that line.

Finally, I have updated the project template link.

As a final suggestion, since MM4 now does cloning from Github for you, it seems more appropriate to keep mm4 in master, and move mm3 to another branch (or tag) which can be easily switched to when using the old style template checkout.
